### PR TITLE
NodeObject.OutputName as interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ TODO.md
 examples/.DS_Store
 examples/img2img/*.png
 jsontest
+
+### jetbrain goland
+.idea

--- a/client/comfyclientrequests.go
+++ b/client/comfyclientrequests.go
@@ -300,7 +300,7 @@ func (c *ComfyClient) QueuePrompt(graph *graphapi.Graph) (*QueueItem, error) {
 		//			  },
 		// "node_errors": []
 		// }
-		perror := &PrompErrorMessage{}
+		perror := &PromptErrorMessage{}
 		perr := json.Unmarshal(body, &perror)
 		if perr != nil {
 			// return the original error

--- a/client/dataitems.go
+++ b/client/dataitems.go
@@ -2,7 +2,7 @@ package client
 
 import "github.com/richinsley/comfy2go/graphapi"
 
-// There may be other DataOutput types.  We defeinitely need a text type
+// There may be other DataOutput types.  We definitely need a text type
 
 type DataOutput struct {
 	Filename  string `json:"filename"`
@@ -51,7 +51,7 @@ type PromptError struct {
 	ExtraInfo map[string]interface{} `json:"extra_info"`
 }
 
-type PrompErrorMessage struct {
+type PromptErrorMessage struct {
 	Error      PromptError   `json:"error"`
 	NodeErrors []interface{} `json:"node_errors"`
 }

--- a/graphapi/nodeobjects.go
+++ b/graphapi/nodeobjects.go
@@ -15,7 +15,7 @@ type NodeObject struct {
 	Input               *NodeObjectInput     `json:"input"`
 	Output              *[]interface{}       `json:"output"` // output type
 	OutputIsList        *[]bool              `json:"output_is_list"`
-	OutputName          *[]string            `json:"output_name"`
+	OutputName          interface{}          `json:"output_name"`
 	Name                string               `json:"name"`
 	DisplayName         string               `json:"display_name"`
 	Description         string               `json:"description"`

--- a/graphapi/nodeobjects.go
+++ b/graphapi/nodeobjects.go
@@ -15,7 +15,7 @@ type NodeObject struct {
 	Input               *NodeObjectInput     `json:"input"`
 	Output              *[]interface{}       `json:"output"` // output type
 	OutputIsList        *[]bool              `json:"output_is_list"`
-	OutputName          interface{}          `json:"output_name"`
+	OutputName          *interface{}         `json:"output_name"`
 	Name                string               `json:"name"`
 	DisplayName         string               `json:"display_name"`
 	Description         string               `json:"description"`

--- a/graphapi/properties.go
+++ b/graphapi/properties.go
@@ -110,7 +110,7 @@ func (b *BaseProperty) GetValue() interface{} {
 
 // SetValue calls the protocol implementation for valueFromString to get
 // the actual value that will be set.  valueFromString should perform
-// conversion to it's native type and constrain it when needed
+// conversion to its native type and constrain it when needed
 func (b *BaseProperty) SetValue(v interface{}) error {
 	vs := fmt.Sprintf("%v", v)
 	val := b.parent.valueFromString(vs)


### PR DESCRIPTION
Thanks for the recent changes, I have been trying them out and on my side I had found a couple of issues. Thankfully it was an easy fix.

https://github.com/YanWenKun/ComfyUI-Docker - This is the ComfyUI I am using, I am hoping it's the latest version.
[workflow(1).json](https://github.com/richinsley/comfy2go/files/14468112/workflow.1.json) - The very basic SDXLT workflow.

Seems to have an issue with the type. Changing from `*[]string` to `string` also didn't work.

```
Error initializing client: json: cannot unmarshal string into Go struct field NodeObject.output_name of type []string
Error initializing client: json: cannot unmarshal array into Go struct field NodeObject.output_name of type string
```

I wasn't able to see how OutputName was used elsewhere, however in this case the value seems better as an interface as it will accept all types.

```
OutputName          interface{}          `json:"output_name"`
```

* Also a quick update to `.gitignore` for goland. :)
* Typo and spelling changes