### PR TITLE
fix: check slice length on properties input

### DIFF
--- a/graphapi/properties.go
+++ b/graphapi/properties.go
@@ -798,6 +798,11 @@ func NewPropertyFromInput(input_name string, optional bool, input *interface{}, 
 			}
 		} else {
 			if stype, ok := slice[0].(string); ok {
+				// This will prevent panic: runtime error: index out of range [1] with length 1
+				if len(slice) < 2 {
+					return newUnknownProperty(input_name, optional, stype, index)
+				}
+
 				switch stype {
 				case "STRING":
 					return newStringProperty(input_name, optional, slice[1], index)


### PR DESCRIPTION
Fix for issue https://github.com/richinsley/comfy2go/issues/12

```
panic: runtime error: index out of range [1] with length 1

goroutine 517 [running]:
github.com/richinsley/comfy2go/graphapi.NewPropertyFromInput({0xc0009002e3, 0x9}, 0x0, 0x9?, 0x0)
	/home/maxx/go/pkg/mod/github.com/richinsley/comfy2go@v0.6.2/graphapi/properties.go:807 +0x619
github.com/richinsley/comfy2go/graphapi.(*NodeObjects).PopulateInputProperties(0xc00007e078)
	/home/maxx/go/pkg/mod/github.com/richinsley/comfy2go@v0.6.2/graphapi/nodeobjects.go:153 +0x225
github.com/richinsley/comfy2go/client.(*ComfyClient).GetObjectInfos(0xc0002bd030?)
```

A simple work around that got this working for me again was checking the slice length. If the slice length is < 2 then we will return the default unknown property.

```
				if len(slice) < 2 {
					return newUnknownProperty(input_name, optional, stype, index)
				}
```