### PR TITLE
fix: review group.go types for bounding nodes

### DIFF
--- a/graphapi/group.go
+++ b/graphapi/group.go
@@ -34,7 +34,7 @@ func (r *Group) IntersectsOrContains(node *GraphNode) bool {
 			pos[i] = v[fmt.Sprintf("%d", i)]
 		}
 	default:
-		slog.Warn("Node position is not of expected type []interface{}, map[int]float64, or map[string]interface{}", "type", fmt.Sprintf("%T", node.Position))
+		slog.Warn("Node position is not of expected type []interface{} or map[string]interface{}", "type", fmt.Sprintf("%T", node.Position))
 		return false
 	}
 

--- a/graphapi/properties.go
+++ b/graphapi/properties.go
@@ -798,6 +798,11 @@ func NewPropertyFromInput(input_name string, optional bool, input *interface{}, 
 			}
 		} else {
 			if stype, ok := slice[0].(string); ok {
+				// This will prevent panic: runtime error: index out of range [1] with length 1
+				if len(slice) < 2 {
+					return newUnknownProperty(input_name, optional, stype, index)
+				}
+
 				switch stype {
 				case "STRING":
 					return newStringProperty(input_name, optional, slice[1], index)


### PR DESCRIPTION
Fix for https://github.com/richinsley/comfy2go/issues/13

In my experiences with the recent ComfyUi updates the type has changed to determine the position of group boxes.

We now have `[]interface{}` and also `map[string]interface{}`. I had tested with both files in the issue mentioned and both are now working as expected.

Previously was unable to target and change any values of nodes inside the API group.