### PR TITLE
fix: avoid panic with newStringProperty

### DIFF
--- a/graphapi/properties.go
+++ b/graphapi/properties.go
@@ -488,7 +488,9 @@ func newStringProperty(input_name string, optional bool, data interface{}, index
 	if d, ok := data.(map[string]interface{}); ok {
 		// default?
 		if val, ok := d["default"]; ok {
-			c.Default = val.(string)
+			if s, ok := val.(string); ok {
+				c.Default = s
+			}
 		}
 
 		// multiline?


### PR DESCRIPTION
- Recent update to ComfyUI 3.41 had caused a panic
- Reviewed the problem, and can confirm it works with the newest and also older versions of ComfyUI.